### PR TITLE
Set environment variables in Dockerfile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -15,4 +15,8 @@ RUN echo "## Done"
 
 RUN echo "## Installing wasienv"
 RUN curl https://raw.githubusercontent.com/wasienv/wasienv/master/install.sh | sh
+
+ENV WASIENV_DIR="/root/.wasienv"
+ENV PATH="$WASIENV_DIR/bin:$PATH"
+
 RUN echo "## Done"


### PR DESCRIPTION
On following the steps described in the "[More elaborated Hello World](https://github.com/wasienv/wasienv/tree/master/docker)" example to the letter, the `docker run` command responds with the following error:

`docker: Error response from daemon: OCI runtime create failed: container_linux.go:346: starting container process caused "exec: \"wasic++\": executable file not found in $PATH": unknown.`

This error results from the path to the `wasienv` bin directory not being set. The current pull request resolves this by setting the path through [environment replacement](https://docs.docker.com/engine/reference/builder/#environment-replacement) in the Dockerfile.