### PR TITLE
Fix missing import in wasinm

### DIFF
--- a/wasienv/wasinm.py
+++ b/wasienv/wasinm.py
@@ -5,7 +5,7 @@ from __future__ import print_function
 import sys
 
 from .tools import logger, run_process, execute, check_program
-from .constants import NM
+from .constants import NM, RANLIB
 
 
 


### PR DESCRIPTION
`wasinm` wouldn't run due to a missing import of a constant. The PR fixes this. 