### PR TITLE
Update CMake to 3.17.1

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -7,9 +7,9 @@ RUN apt-get install -y --no-install-recommends python python-pip python-setuptoo
 RUN echo "## Done"
 
 RUN echo "## Installing CMake"
-RUN curl https://cmake.org/files/v3.6/cmake-3.6.3-Linux-x86_64.sh --output cmake-3.6.3-Linux-x86_64.sh \
+RUN curl https://cmake.org/files/v3.17/cmake-3.17.1-Linux-x86_64.sh --output cmake-3.17.1-Linux-x86_64.sh \
     &&  mkdir /opt/cmake \
-    &&  printf "y\nn\n" | sh cmake-3.6.3-Linux-x86_64.sh --prefix=/opt/cmake > /dev/null \
+    &&  printf "y\nn\n" | sh cmake-3.17.1-Linux-x86_64.sh --prefix=/opt/cmake > /dev/null \
     &&  ln -s /opt/cmake/bin/cmake /usr/local/bin/cmake
 RUN echo "## Done"
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -15,7 +15,7 @@ Each tag was build from single [Dockerfile](https://github.com/wasienv/wasienv/b
 
 |packages|version|
 |---|---|
-|`cmake`|**3.14.3**|
+|`cmake`|**3.17.1**|
 
 ### System installed:
 


### PR DESCRIPTION
Recent versions of CMake add [support for Swift](https://gitlab.kitware.com/cmake/cmake/issues/18800) and other improvements.