### PR TITLE
Fix some compile warnings in preamble.h

### DIFF
--- a/wasienv/stubs/preamble.h
+++ b/wasienv/stubs/preamble.h
@@ -57,7 +57,7 @@ __attribute__((weak)) ssize_t getrandom(void * buffer, size_t len, unsigned flag
 }
 
 
-__attribute__((weak)) char *getcwd(char *buf, size_t size) { return "";}
+__attribute__((weak)) const char *getcwd(char *buf, size_t size) { return "";}
 
 __attribute__((weak))  int clock_settime(clockid_t clk_id, const struct timespec *tp) { return 0;}
 __attribute__((weak)) int chdir(const char *path) { return 0;
@@ -112,8 +112,8 @@ __attribute__((weak)) int chmod(const char *pathname, mode_t mode) { return 0; }
 
 __attribute__((weak)) int signal(int signum, int handler) { return 0; }
 
-__attribute__((weak)) int sigaction(int signum, const struct sigaction *act,
-                     struct sigaction *oldact) { return 0; }
+__attribute__((weak)) int sigaction(int signum, const /* struct sigaction */ void *act,
+                     /* struct sigaction */ void *oldact) { return 0; }
 
 
 
@@ -124,7 +124,7 @@ __attribute__((weak)) void *dlopen(const char *filename, int flag) {
     return NULL;
 }
 
-__attribute__((weak)) char *dlerror(void) {
+__attribute__((weak)) const char *dlerror(void) {
     printf("[WASIENV] dlerror\n");fflush(stdout);
     return "";
 }

--- a/wasienv/stubs/preamble.h
+++ b/wasienv/stubs/preamble.h
@@ -25,7 +25,6 @@ __attribute__((weak)) char *realpath(const char *path, char *resolved_path) { re
 ///
 #define PAGESIZE (0x10000)
 #define PAGE_SIZE PAGESIZE
-#define ESHUTDOWN 1
 
 #define ESHUTDOWN 0
 #define GRND_NONBLOCK 0
@@ -122,6 +121,7 @@ __attribute__((weak)) int sigaction(int signum, const struct sigaction *act,
 
 __attribute__((weak)) void *dlopen(const char *filename, int flag) {
     printf("[WASIENV] dlopen\n");fflush(stdout);
+    return NULL;
 }
 
 __attribute__((weak)) char *dlerror(void) {
@@ -131,9 +131,11 @@ __attribute__((weak)) char *dlerror(void) {
 
 __attribute__((weak)) void *dlsym(void *handle, const char *symbol) {
     printf("[WASIENV] dlsym\n");fflush(stdout);
+    return NULL;
 }
 
 __attribute__((weak)) int dlclose(void *handle) {
     printf("[WASIENV] dlclose\n");fflush(stdout);
+    return 0;
 }
 

--- a/wasienv/wasinm.py
+++ b/wasienv/wasinm.py
@@ -5,12 +5,12 @@ from __future__ import print_function
 import sys
 
 from .tools import logger, run_process, execute, check_program
-from .constants import NM, RANLIB
+from .constants import NM
 
 
 
 def run(args):
-    check_program(RANLIB)
+    check_program(NM)
     proc_args = [NM]+args[1:]
     return_code = run_process(proc_args, check=False)
     return return_code


### PR DESCRIPTION
~~I'm still getting~~
```
/home/coolreader18/.local/lib/python3.8/site-packages/wasienv/stubs/preamble.h:116:62: warning: declaration of 'struct sigaction' will not be visible outside of this function [-Wvisibility]
__attribute__((weak)) int sigaction(int signum, const struct sigaction *act,
```
~~but I'm not sure there's an easy way to fix that.~~

Nevermind, I just replaced the `struct sigaction *` with `void *`