### PR TITLE
Fix `install.sh` remove deprecated pip flag

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -117,12 +117,14 @@ if [ -x "$(command -v pip3)" ]; then
   # Uninstall in case it exists
   pip3 uninstall wasienv -y || true
   # Install wasienv in the ~/.wasienv/bin directory
-  pip3 install wasienv --install-option="--install-scripts=$INSTALL_DIRECTORY/bin" --upgrade --user
+  pip3 install wasienv --prefix=$INSTALL_DIRECTORY --upgrade
+  pip3 install wasienv --user
 else
   # Uninstall in case it exists
   pip uninstall wasienv -y || true
   # Install wasienv in the ~/.wasienv/bin directory
-  pip install wasienv --install-option="--install-scripts=$INSTALL_DIRECTORY/bin" --upgrade --user
+  pip install wasienv --prefix=$INSTALL_DIRECTORY --upgrade
+  pip install wasienv --user
 fi
 
 wasienv_link


### PR DESCRIPTION
Not 100% confident in this solution, this installs both `bin` and `lib` into `~/.wasienv` and then reinstalls it at the user-level so that it's accessible. There's probably a way to use the original install instead, but I don't have enough context on python / pip to know.

At least for now, this fixes the installer.