### PR TITLE
Fix conflicting function types for getcwd

### DIFF
--- a/wasienv/stubs/preamble.h
+++ b/wasienv/stubs/preamble.h
@@ -57,7 +57,7 @@ __attribute__((weak)) ssize_t getrandom(void * buffer, size_t len, unsigned flag
 }
 
 
-__attribute__((weak)) const char *getcwd(char *buf, size_t size) { return "";}
+__attribute__((weak)) char *getcwd(char *buf, size_t size) { return "";}
 
 __attribute__((weak))  int clock_settime(clockid_t clk_id, const struct timespec *tp) { return 0;}
 __attribute__((weak)) int chdir(const char *path) { return 0;


### PR DESCRIPTION
`getcwd` does not have a const in `unistd.h` of the latest WASI SDK. Including the const in preamble causes the following error:

```
In file included from <built-in>:1:
/root/.local/lib/python2.7/site-packages/wasienv/stubs/preamble.h:60:35: error: conflicting types for 'getcwd'
__attribute__((weak)) const char *getcwd(char *buf, size_t size) { return "";}
                                  ^
/root/.local/lib/python2.7/site-packages/wasienv-storage/sdks/12/wasi-sdk-12.0/share/wasi-sysroot/include/unistd.h:125:7: note: previous declaration is here
char *getcwd(char *, size_t);
      ^
```