### PR TITLE
Update to debian buster

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:stretch AS stage_build
+FROM debian:buster AS stage_build
 
 
 RUN echo "## Update and install packages"


### PR DESCRIPTION
Latest wasmer requires GLIBC 2.27 or later, which isn't available in stretch.