### PR TITLE
Add alarm() to the preamble

### DIFF
--- a/wasienv/stubs/preamble.h
+++ b/wasienv/stubs/preamble.h
@@ -110,6 +110,8 @@ __attribute__((weak)) gid_t getegid(void) { return 0; }
 
 __attribute__((weak)) int chmod(const char *pathname, mode_t mode) { return 0; }
 
+__attribute__((weak)) unsigned alarm(unsigned seconds) { return 0; }
+
 __attribute__((weak)) int signal(int signum, int handler) { return 0; }
 
 __attribute__((weak)) int sigaction(int signum, const /* struct sigaction */ void *act,


### PR DESCRIPTION
Alarm isn't supported by WASI: https://github.com/WebAssembly/wasi-libc/blob/5b148b6131f36770f110c24d61adfb1e17fea06a/libc-top-half/musl/include/unistd.h#L127

This allows projects using alarm to compile and should be included along with the signal definitions.